### PR TITLE
`Rfc5424` formatter configuration

### DIFF
--- a/tracing-rfc-5424/src/layer.rs
+++ b/tracing-rfc-5424/src/layer.rs
@@ -278,11 +278,12 @@ mod smoke {
     // needs a reference with 'static duration.
     impl TestCallsite {
         pub const fn new(metadata: &'static tracing::Metadata<'static>) -> TestCallsite {
-            TestCallsite { metadata: metadata }
+            TestCallsite { metadata }
         }
     }
 
     #[test]
+    #[allow(clippy::redundant_closure_call)]
     fn test_rfc_5424_impl() {
         // Just exercise `default()`; be sure it compiles & returns something sane.
         let _f = Rfc5424::default();
@@ -296,7 +297,7 @@ mod smoke {
             .unwrap()
             .build();
 
-        let fmtr = TrivialTracingFormatter::default();
+        let _fmtr = TrivialTracingFormatter::default();
 
         // Non-macro replication of the logic of `event!()`-- will need to wrap this up in a macro
         // at some point.
@@ -383,9 +384,9 @@ mod smoke {
 
             let mut golden =
                 Vec::from("<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - - ");
-            golden.push(0xef as u8);
-            golden.push(0xbb as u8);
-            golden.push(0xbf as u8);
+            golden.push(0xef_u8);
+            golden.push(0xbb_u8);
+            golden.push(0xbf_u8);
             golden.extend_from_slice("Hello, world!".as_bytes());
 
             assert_eq!(rsp, golden);

--- a/tracing-rfc-5424/src/layer.rs
+++ b/tracing-rfc-5424/src/layer.rs
@@ -192,7 +192,17 @@ where
         Layer {
             syslog_formatter: Rfc5424::default(),
             tracing_formatter: TrivialTracingFormatter::default(),
-            transport: transport,
+            transport,
+            subscriber_type: std::marker::PhantomData,
+        }
+    }
+
+    /// Construct a Layer that will send RFC5424-compliant messages via transport `transport`
+    pub fn with_transport_and_syslog_formatter(transport: T, formatter: Rfc5424) -> Self {
+        Layer {
+            syslog_formatter: formatter,
+            tracing_formatter: TrivialTracingFormatter::default(),
+            transport,
             subscriber_type: std::marker::PhantomData,
         }
     }

--- a/tracing-rfc-5424/src/rfc3164.rs
+++ b/tracing-rfc-5424/src/rfc3164.rs
@@ -236,11 +236,9 @@ pub struct Tag(Vec<u8>);
 impl Tag {
     pub fn new(bytes: Vec<u8>) -> Result<Tag> {
         if bytes.len() <= 32
-            && bytes.iter().all(|&x| {
-                (b'0'..=b'9').contains(&x)
-                    || (b'A'..=b'Z').contains(&x)
-                    || (b'a'..=b'z').contains(&x)
-            })
+            && bytes
+                .iter()
+                .all(|&x| x.is_ascii_digit() || x.is_ascii_uppercase() || x.is_ascii_lowercase())
         {
             Ok(Tag(bytes))
         } else {
@@ -253,11 +251,7 @@ impl Tag {
     /// Strip non-compliant ASCII characters
     fn strip_non_compliant(x: Vec<u8>) -> Vec<u8> {
         x.into_iter()
-            .filter(|&x| {
-                (b'0'..=b'9').contains(&x)
-                    || (b'A'..=b'Z').contains(&x)
-                    || (b'a'..=b'z').contains(&x)
-            })
+            .filter(|&x| x.is_ascii_digit() || x.is_ascii_uppercase() || x.is_ascii_lowercase())
             .collect()
     }
     pub fn try_default() -> Result<Tag> {
@@ -401,7 +395,8 @@ impl SyslogFormatter for Rfc3164 {
         let mut buf = format!(
             "<{}>{} ",
             self.facility as u8 | level as u8,
-            timestamp.map(|d| d.with_timezone(&Local))
+            timestamp
+                .map(|d| d.with_timezone(&Local))
                 .or_else(|| Some(Local::now()))
                 .unwrap()
                 .format("%b %_d %H:%M:%S"),

--- a/tracing-rfc-5424/src/rfc5424.rs
+++ b/tracing-rfc-5424/src/rfc5424.rs
@@ -101,7 +101,9 @@ impl std::fmt::Display for Error {
                 "While extracting the name of the current host, got {}",
                 source
             ),
-            _ => write!(f, "RRC 5424 error: {}", self),
+            Error::BadProcId { name, back } => {
+                write!(f, "Bad proc id. name: {name:?}, backtrace: {back:?}",)
+            }
         }
     }
 }

--- a/tracing-rfc-5424/src/rfc5424.rs
+++ b/tracing-rfc-5424/src/rfc5424.rs
@@ -109,9 +109,7 @@ impl std::fmt::Display for Error {
 impl std::fmt::Debug for Error {
     #[allow(unreachable_patterns)]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            _ => write!(f, "RFC 5424 error: {}", self),
-        }
+        write!(f, "RFC 5424 error: {}", self)
     }
 }
 
@@ -245,7 +243,7 @@ impl std::default::Default for AppName {
                 AppName::new(match pbuf.file_name() {
                     // Arrrghhhh... wicked copy!
                     Some(os_str) => bytes_from_os_str(os_str.to_os_string()),
-                    None => vec!['-' as u8],
+                    None => vec![b'-'],
                 })
             })
             .unwrap()
@@ -411,9 +409,9 @@ impl SyslogFormatter for Rfc5424 {
         // byte order mask (BOM), which for UTF-8 is ABNF %xEF.BB.BF.  The syslog application
         // MUST encode in the "shortest form" and MAY use any valid UTF-8 sequence."
         if self.with_bom {
-            buf.put_u8(0xef as u8);
-            buf.put_u8(0xbb as u8);
-            buf.put_u8(0xbf as u8);
+            buf.put_u8(0xef_u8);
+            buf.put_u8(0xbb_u8);
+            buf.put_u8(0xbf_u8);
         }
 
         buf.put_slice(msg.as_bytes());

--- a/tracing-rfc-5424/src/tracing.rs
+++ b/tracing-rfc-5424/src/tracing.rs
@@ -201,7 +201,6 @@ where
             .ok_or(Error::NoMessageField {
                 name: event.metadata().name(),
                 back: Backtrace::new(),
-            })
-            .and_then(|s| Ok(Some((s, (*self.map_level)(event.metadata().level())))))
+            }).map(|s| Some((s, (*self.map_level)(event.metadata().level()))))
     }
 }

--- a/tracing-rfc-5424/src/transport.rs
+++ b/tracing-rfc-5424/src/transport.rs
@@ -230,7 +230,7 @@ where
         writer.write(&[10])?;
         writer.flush()?;
 
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -325,6 +325,6 @@ where
         writer.write(&[10])?;
         writer.flush()?;
 
-        return Ok(());
+        Ok(())
     }
 }

--- a/tracing-rfc-5424/src/transport.rs
+++ b/tracing-rfc-5424/src/transport.rs
@@ -72,10 +72,7 @@ use crate::formatter::SyslogFormatter;
 
 use backtrace::Backtrace;
 
-use std::{
-    net::TcpStream,
-    path::Path,
-};
+use std::{net::TcpStream, path::Path};
 
 #[cfg(unix)]
 use std::os::unix::net::{UnixDatagram, UnixStream};
@@ -226,8 +223,8 @@ where
         //
         // Reddit discussion here:
         // <https://www.reddit.com/r/rust/comments/v2uxze/getting_a_mutable_reference_to_self_in_a_method/>
-        writer.write(&buf)?;
-        writer.write(&[10])?;
+        writer.write_all(&buf)?;
+        writer.write_all(&[10])?;
         writer.flush()?;
 
         Ok(())
@@ -321,8 +318,8 @@ where
         //
         // Reddit discussion here:
         // <https://www.reddit.com/r/rust/comments/v2uxze/getting_a_mutable_reference_to_self_in_a_method/>
-        writer.write(&buf)?;
-        writer.write(&[10])?;
+        writer.write_all(&buf)?;
+        writer.write_all(&[10])?;
         writer.flush()?;
 
         Ok(())


### PR DESCRIPTION
- Add a `with_transport_and_syslog_formatter` function to construct a layer with it's own `Rfc5424` formatter.
- Fix clippy lints 