### PR TITLE
fix: build for target x86_64-pc-windows-gnu

### DIFF
--- a/test-rfc-5424/src/bin/unix-socket-test.rs
+++ b/test-rfc-5424/src/bin/unix-socket-test.rs
@@ -15,23 +15,35 @@
 
 //! Test writing to `/dev/log` on the local host.
 
-use tracing::{debug, error, info, trace, warn};
-use tracing_rfc_5424::{
-    layer::Layer, rfc3164::Rfc3164, tracing::TrivialTracingFormatter, transport::UnixSocket,
-};
-use tracing_subscriber::{
-    layer::SubscriberExt, // Needed to get `with()`
-    registry::Registry,
-};
+#[cfg(unix)]
+mod test {
+    use tracing::{debug, error, info, trace, warn};
+    use tracing_rfc_5424::{
+        layer::Layer, rfc3164::Rfc3164, tracing::TrivialTracingFormatter, transport::UnixSocket,
+    };
+    use tracing_subscriber::{
+        layer::SubscriberExt, // Needed to get `with()`
+        registry::Registry,
+    };
+
+    pub fn run() {
+        let subscriber = Registry::default()
+        .with(Layer::<tracing_subscriber::Registry, Rfc3164, TrivialTracingFormatter, UnixSocket>::try_default().unwrap());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        trace!("你好, Unix domain socket.");
+        debug!("你好, Unix domain socket.");
+        info!("你好, Unix domain socket.");
+        warn!("你好, Unix domain socket.");
+        error!("你好, Unix domain socket.");
+    }
+}
+
+#[cfg(not(unix))]
+mod test {
+    pub fn run() {}
+}
 
 pub fn main() {
-    let subscriber = Registry::default()
-        .with(Layer::<tracing_subscriber::Registry, Rfc3164, TrivialTracingFormatter, UnixSocket>::try_default().unwrap());
-    let _guard = tracing::subscriber::set_default(subscriber);
-
-    trace!("你好, Unix domain socket.");
-    debug!("你好, Unix domain socket.");
-    info!("你好, Unix domain socket.");
-    warn!("你好, Unix domain socket.");
-    error!("你好, Unix domain socket.");
+    test::run()
 }

--- a/tracing-rfc-5424/src/layer.rs
+++ b/tracing-rfc-5424/src/layer.rs
@@ -27,8 +27,11 @@ use crate::{
     rfc3164::Rfc3164,
     rfc5424::Rfc5424,
     tracing::{TracingFormatter, TrivialTracingFormatter},
-    transport::{Transport, UdpTransport, UnixSocket},
+    transport::{Transport, UdpTransport},
 };
+
+#[cfg(unix)]
+use crate::transport::UnixSocket;
 
 use backtrace::Backtrace;
 use tracing::Event;
@@ -150,6 +153,7 @@ where
 ///
 /// [`tracing_subscriber::Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 /// [`LookupSpan`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/registry/trait.LookupSpan.html
+#[cfg(unix)]
 impl<S> Layer<S, Rfc3164, TrivialTracingFormatter, UnixSocket>
 where
     S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,


### PR DESCRIPTION
`transport::UnixSocket` is not available on windows targets.

Gate code using it with `#[cfg(unix)]`