### PR TITLE
windows not to panic

### DIFF
--- a/tracing-rfc-5424/src/byte-utils.rs
+++ b/tracing-rfc-5424/src/byte-utils.rs
@@ -22,5 +22,5 @@ pub fn bytes_from_os_str(s: std::ffi::OsString) -> Vec<u8> {
 
 #[cfg(not(unix))]
 pub fn bytes_from_os_str(s: std::ffi::OsString) -> Vec<u8> {
-    unimplemented!("bytes_from_os_str is not supported on non-Unix.");
+    s.to_string_lossy().as_bytes().to_vec()
 }

--- a/tracing-rfc-5424/src/rfc5424.rs
+++ b/tracing-rfc-5424/src/rfc5424.rs
@@ -59,7 +59,7 @@ pub enum Error {
     },
     /// Failed to format the `tracing` Event
     BadTracingFormat {
-        source: Box<dyn std::error::Error>,
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
         back: Backtrace,
     },
     /// Failed to fetch the current executable (via std::env)


### PR DESCRIPTION
Why not support windows platform? There is no obstructioon.

The Error derives Send and Sync that can works well in async world.