### PR TITLE
allow sending tracing metadata (target, file/line, module_path) as syslog structured data.

### DIFF
--- a/test-rfc-5424/Cargo.toml
+++ b/test-rfc-5424/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.5"
 edition = "2021"
 
 [dependencies]
+syslog_rfc5424 = "0.9"
 tracing = "0.1.36"
 tracing-rfc-5424 = { version = "0.1", path = "../tracing-rfc-5424"}
 tracing-subscriber = "0.3.15"

--- a/tracing-rfc-5424/Cargo.toml
+++ b/tracing-rfc-5424/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["development-tools::debugging"]
 
 
 [features]
-default = []
+default = ["tracing-log"]
 # Enable compatibility with the `log` crate. When enabled, events from the `log` crate
 # that are bridged via tracing-log will have their file/line metadata preserved.
-tracing-log = ["dep:tracing-log"]
+tracing-log = ["dep:tracing-log", "tracing-subscriber/tracing-log"]
 
 [dependencies]
 backtrace = "0.3.66"
@@ -27,7 +27,8 @@ local-ip-address = "0.4.5"
 tracing = "0.1.35"
 tracing-core = "0.1.28"
 tracing-log = { version = "0.2", optional = true }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { version = "0.3.22", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 syslog_rfc5424 = "0.10"
+tracing-subscriber = { version = "0.3.22", default-features = false, features = ["registry"] }

--- a/tracing-rfc-5424/Cargo.toml
+++ b/tracing-rfc-5424/Cargo.toml
@@ -12,6 +12,12 @@ keywords = ["tracing", "syslog", "rfc-3164", "rfc-5424"]
 categories = ["development-tools::debugging"]
 
 
+[features]
+default = []
+# Enable compatibility with the `log` crate. When enabled, events from the `log` crate
+# that are bridged via tracing-log will have their file/line metadata preserved.
+tracing-log = ["dep:tracing-log"]
+
 [dependencies]
 backtrace = "0.3.66"
 bytes = "1.2.0"
@@ -20,6 +26,7 @@ hostname = "0.3.1"
 local-ip-address = "0.4.5"
 tracing = "0.1.35"
 tracing-core = "0.1.28"
+tracing-log = { version = "0.2", optional = true }
 tracing-subscriber = "0.3.15"
 
 [dev-dependencies]

--- a/tracing-rfc-5424/Cargo.toml
+++ b/tracing-rfc-5424/Cargo.toml
@@ -21,3 +21,6 @@ local-ip-address = "0.4.5"
 tracing = "0.1.35"
 tracing-core = "0.1.28"
 tracing-subscriber = "0.3.15"
+
+[dev-dependencies]
+syslog_rfc5424 = "0.10"

--- a/tracing-rfc-5424/Cargo.toml
+++ b/tracing-rfc-5424/Cargo.toml
@@ -30,5 +30,5 @@ tracing-log = { version = "0.2", optional = true }
 tracing-subscriber = { version = "0.3.22", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-syslog_rfc5424 = "0.10"
+syslog_rfc5424 = "0.9"
 tracing-subscriber = { version = "0.3.22", default-features = false, features = ["registry"] }

--- a/tracing-rfc-5424/src/formatter.rs
+++ b/tracing-rfc-5424/src/formatter.rs
@@ -61,6 +61,6 @@ pub trait SyslogFormatter {
         level: Level,
         msg: &str,
         timestamp: Option<DateTime<Utc>>,
-        metadata: &'static tracing_core::Metadata<'static>,
+        metadata: &tracing_core::Metadata<'_>,
     ) -> std::result::Result<Self::Output, Self::Error>;
 }

--- a/tracing-rfc-5424/src/formatter.rs
+++ b/tracing-rfc-5424/src/formatter.rs
@@ -61,5 +61,6 @@ pub trait SyslogFormatter {
         level: Level,
         msg: &str,
         timestamp: Option<DateTime<Utc>>,
+        metadata: &'static tracing_core::Metadata<'static>,
     ) -> std::result::Result<Self::Output, Self::Error>;
 }

--- a/tracing-rfc-5424/src/layer.rs
+++ b/tracing-rfc-5424/src/layer.rs
@@ -448,7 +448,7 @@ mod smoke {
             .unwrap()
             .pid_as_string("123".to_string())
             .unwrap()
-            .include_target(true)
+            .with_tracing_target(true)
             .build();
 
         static CALLSITE: TestCallsite = {
@@ -479,7 +479,7 @@ mod smoke {
 
         assert_eq!(
             std::str::from_utf8(&rsp).unwrap(),
-            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [meta target=\"test-target\"] Hello, world!"
+            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [tracing-meta@64700 target=\"test-target\"] Hello, world!"
         );
 
         // Test with include_source_location enabled
@@ -490,7 +490,7 @@ mod smoke {
             .unwrap()
             .pid_as_string("123".to_string())
             .unwrap()
-            .include_source_location(true)
+            .with_tracing_source_location(true)
             .build();
 
         let rsp: Vec<u8> = f_loc
@@ -507,7 +507,7 @@ mod smoke {
         let expected_file = CALLSITE.metadata().file().unwrap();
         let expected_line = CALLSITE.metadata().line().unwrap();
         let expected = format!(
-            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [meta file=\"{}\" line=\"{}\"] Hello, world!",
+            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [tracing-meta@64700 file=\"{}\" line=\"{}\"] Hello, world!",
             expected_file, expected_line
         );
         assert_eq!(output, expected);
@@ -520,7 +520,7 @@ mod smoke {
             .unwrap()
             .pid_as_string("123".to_string())
             .unwrap()
-            .include_module(true)
+            .with_tracing_module(true)
             .build();
 
         let rsp: Vec<u8> = f_module
@@ -536,7 +536,7 @@ mod smoke {
         // Should contain module but not target or file/line
         let expected_module = CALLSITE.metadata().module_path().unwrap();
         let expected = format!(
-            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [meta module=\"{}\"] Hello, world!",
+            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [tracing-meta@64700 module=\"{}\"] Hello, world!",
             expected_module
         );
         assert_eq!(output, expected);
@@ -549,8 +549,8 @@ mod smoke {
             .unwrap()
             .pid_as_string("123".to_string())
             .unwrap()
-            .include_target(true)
-            .include_source_location(true)
+            .with_tracing_target(true)
+            .with_tracing_source_location(true)
             .build();
 
         let rsp: Vec<u8> = f_both
@@ -567,7 +567,7 @@ mod smoke {
         let expected_file = CALLSITE.metadata().file().unwrap();
         let expected_line = CALLSITE.metadata().line().unwrap();
         let expected = format!(
-            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [meta target=\"test-target\" file=\"{}\" line=\"{}\"] Hello, world!",
+            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [tracing-meta@64700 target=\"test-target\" file=\"{}\" line=\"{}\"] Hello, world!",
             expected_file, expected_line
         );
         assert_eq!(output, expected);
@@ -580,9 +580,9 @@ mod smoke {
             .unwrap()
             .pid_as_string("123".to_string())
             .unwrap()
-            .include_target(true)
-            .include_module(true)
-            .include_source_location(true)
+            .with_tracing_target(true)
+            .with_tracing_module(true)
+            .with_tracing_source_location(true)
             .build();
 
         let rsp: Vec<u8> = f_all
@@ -600,7 +600,7 @@ mod smoke {
         let expected_file = CALLSITE.metadata().file().unwrap();
         let expected_line = CALLSITE.metadata().line().unwrap();
         let expected = format!(
-            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [meta target=\"test-target\" module=\"{}\" file=\"{}\" line=\"{}\"] Hello, world!",
+            "<14>1 1970-01-01T00:00:00+00:00 bree.local prototyping 123 - [tracing-meta@64700 target=\"test-target\" module=\"{}\" file=\"{}\" line=\"{}\"] Hello, world!",
             expected_module, expected_file, expected_line
         );
         assert_eq!(output, expected);

--- a/tracing-rfc-5424/src/layer.rs
+++ b/tracing-rfc-5424/src/layer.rs
@@ -249,7 +249,7 @@ where
         // file/line info for events that originated from the `log` crate.
         // For native tracing events, normalized_metadata() returns None and we use
         // the event's own metadata.
-        // See: https://github.com/tokio-rs/tracing/blob/master/tracing-subscriber/src/fmt/fmt_layer.rs
+        // See: https://github.com/tokio-rs/tracing/blob/9978c3663bcd58de14b3cf089ad24cb63d00a922/tracing-subscriber/src/fmt/format/pretty.rs#L182
         #[cfg(feature = "tracing-log")]
         let normalized_meta = event.normalized_metadata();
         #[cfg(feature = "tracing-log")]

--- a/tracing-rfc-5424/src/rfc3164.rs
+++ b/tracing-rfc-5424/src/rfc3164.rs
@@ -391,6 +391,7 @@ impl SyslogFormatter for Rfc3164 {
         level: Level,
         msg: &str,
         timestamp: Option<DateTime<Utc>>,
+        _metadata: &'static tracing_core::Metadata<'static>,
     ) -> Result<Self::Output> {
         let mut buf = format!(
             "<{}>{} ",

--- a/tracing-rfc-5424/src/rfc3164.rs
+++ b/tracing-rfc-5424/src/rfc3164.rs
@@ -391,7 +391,7 @@ impl SyslogFormatter for Rfc3164 {
         level: Level,
         msg: &str,
         timestamp: Option<DateTime<Utc>>,
-        _metadata: &'static tracing_core::Metadata<'static>,
+        _metadata: &tracing_core::Metadata<'_>,
     ) -> Result<Self::Output> {
         let mut buf = format!(
             "<{}>{} ",

--- a/tracing-rfc-5424/src/rfc5424.rs
+++ b/tracing-rfc-5424/src/rfc5424.rs
@@ -488,7 +488,7 @@ impl SyslogFormatter for Rfc5424 {
         level: Level,
         msg: &str,
         timestamp: Option<DateTime<Utc>>,
-        metadata: &'static tracing_core::Metadata<'static>,
+        metadata: &tracing_core::Metadata<'_>,
     ) -> Result<Self::Output> {
         let mut buf = format!(
             "<{}>1 {} ",

--- a/tracing-rfc-5424/src/rfc5424.rs
+++ b/tracing-rfc-5424/src/rfc5424.rs
@@ -526,14 +526,17 @@ impl Rfc5424Builder {
     }
     /// Override the SD-ID used with tracing metadata. By default it is "tracing-meta@64700"
     pub fn with_tracing_metadata_sdid(mut self, sd_id: String) -> Self {
-        self.imp.with_tracing_metadata.get_or_insert_default().sd_id = sd_id;
+        self.imp
+            .with_tracing_metadata
+            .get_or_insert_with(Default::default)
+            .sd_id = sd_id;
         self
     }
     /// Send the "target" with each tracing event, as part of the tracing metadata
     pub fn with_tracing_target(mut self, with_target: bool) -> Self {
         self.imp
             .with_tracing_metadata
-            .get_or_insert_default()
+            .get_or_insert_with(Default::default)
             .target = with_target;
         self
     }
@@ -541,7 +544,7 @@ impl Rfc5424Builder {
     pub fn with_tracing_module(mut self, with_module: bool) -> Self {
         self.imp
             .with_tracing_metadata
-            .get_or_insert_default()
+            .get_or_insert_with(Default::default)
             .module = with_module;
         self
     }
@@ -549,7 +552,7 @@ impl Rfc5424Builder {
     pub fn with_tracing_source_location(mut self, with_source_location: bool) -> Self {
         self.imp
             .with_tracing_metadata
-            .get_or_insert_default()
+            .get_or_insert_with(Default::default)
             .source_location = with_source_location;
         self
     }

--- a/tracing-rfc-5424/src/rfc5424.rs
+++ b/tracing-rfc-5424/src/rfc5424.rs
@@ -403,12 +403,18 @@ mod test_names {
 
         // Verify the custom SD-ID is used
         let target_value = parsed.sd.find_tuple("custom@12345", "target");
-        assert!(target_value.is_some(), "target parameter not found with custom SD-ID");
+        assert!(
+            target_value.is_some(),
+            "target parameter not found with custom SD-ID"
+        );
         assert_eq!(target_value.unwrap(), "test_target");
 
         // Verify the default SD-ID is NOT used
         let default_target = parsed.sd.find_tuple("tracing-meta@64700", "target");
-        assert!(default_target.is_none(), "default SD-ID should not be present");
+        assert!(
+            default_target.is_none(),
+            "default SD-ID should not be present"
+        );
     }
 }
 

--- a/tracing-rfc-5424/src/rfc5424.rs
+++ b/tracing-rfc-5424/src/rfc5424.rs
@@ -679,26 +679,3 @@ impl SyslogFormatter for Rfc5424 {
         Ok(buf)
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_against_issue_014_regression() {
-        let test_message = String::from_utf8(Rfc5424::builder()
-            .facility(Facility::LOG_USER)
-            .hostname_as_string("bree".to_owned())
-            .unwrap(/* known good */)
-            .appname_as_string("unit test suite".to_owned())
-            .unwrap(/* known good */)
-            .build()
-            .format(Level::LOG_NOTICE, "This is a test message; its timestamp had better not have more than 6 digits in the fractional seconds place", None)
-            .unwrap(/* known good */))
-            .unwrap(/* known good */);
-        eprintln!("Test message: {test_message}\n");
-        let i = test_message.find('.').unwrap(/* known good */);
-        let j = test_message.find('+').unwrap(/* known good */);
-        assert!(j - i - 1 <= 6);
-    }
-}


### PR DESCRIPTION
this adds optional features to pass on more of the metadata from the tracing infrastructure as structured-data, when using RFC-5424 format.

it doesn't go as far as sending fields and valuesets from tracing events, but still seems like a significant improvement.

note that `tracing_subscriber` typically defaults to formatting the target with the log message in text logs, so many users are used to seeing that in text logs, but it's not present in the syslog records produced by this crate before this change. in tracing_subscriber, the file and line number are optional defaulting to off. in this PR we make all this stuff default to off, for backwards compatible behavior.